### PR TITLE
Fix Delete Button not working on Recommendation Table

### DIFF
--- a/frontend/src/main/components/Recommendations/RecommendationsTable.js
+++ b/frontend/src/main/components/Recommendations/RecommendationsTable.js
@@ -1,19 +1,8 @@
 import OurTable, { ButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import {  onDeleteSuccess } from "main/utils/RecommendationsUtils"
+import {  onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/RecommendationsUtils"
 // import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
-
-
-export function cellToAxiosParamsDelete(cell) {
-    return {
-        url: "/api/recommendationrequests",
-        method: "DELETE",
-        params: {
-            requesterEmail: cell.row.values.requesterEmail
-        }
-    }
-}
 
 export default function RecommendationsTable({ recommendations, currentUser }) {
 

--- a/frontend/src/main/utils/RecommendationsUtils.js
+++ b/frontend/src/main/utils/RecommendationsUtils.js
@@ -10,7 +10,7 @@ export function cellToAxiosParamsDelete(cell) {
         url: "/api/recommendationrequests",
         method: "DELETE",
         params: {
-            requesterEmail: cell.row.values.requesterEmail
+            id: cell.row.values.id
         }
     }
 }

--- a/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
@@ -140,7 +140,7 @@ describe("RecommendationsIndexPage tests", () => {
           expect(header).toBeInTheDocument();
         });
 
-        expect(queryByTestId(`${testId}-cell-row-0-col-requesterEmail`)).not.toBeInTheDocument();
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
     test("test what happens when you click delete, admin", async () => {
@@ -148,7 +148,7 @@ describe("RecommendationsIndexPage tests", () => {
 
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/recommendationrequests/all").reply(200, recommendationsFixtures.threeRecommendations);
-        axiosMock.onDelete("/api/recommendationrequests",  {params: {requesterEmail: "supbub@gmail.com"}}).reply(200, "Recommendation with requesterEmail supbub@gmail.com was deleted");
+        axiosMock.onDelete("/api/recommendationrequests").reply(200, "Recommendation with id 1 was deleted");
 
         const { getByTestId } = render(
             <QueryClientProvider client={queryClient}>
@@ -158,9 +158,9 @@ describe("RecommendationsIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-requesterEmail`)).toBeInTheDocument(); });
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
-        expect(getByTestId(`${testId}-cell-row-0-col-requesterEmail`)).toHaveTextContent("supbub@gmail.com"); 
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
 
 
         const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
@@ -168,9 +168,11 @@ describe("RecommendationsIndexPage tests", () => {
 
         fireEvent.click(deleteButton);
 
-        await waitFor(() => { expect(mockToast).toBeCalledWith("Recommendation with requesterEmail supbub@gmail.com was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Recommendation with id 1 was deleted") });
 
     });
 
 });
+
+
 

--- a/frontend/src/tests/utils/RecommendationsUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationsUtils.test.js
@@ -36,7 +36,7 @@ describe("Recommendations", () => {
 
         test("It returns the correct params", () => {
             // arrange
-            const cell = { row: { values: { requesterEmail: "supbub@gmail.com" } } };
+            const cell = { row: { values: { id: "1" } } };
 
             // act
             const result = cellToAxiosParamsDelete(cell);
@@ -45,7 +45,7 @@ describe("Recommendations", () => {
             expect(result).toEqual({
                 url: "/api/recommendationrequests",
                 method: "DELETE",
-                params: { requesterEmail: "supbub@gmail.com" }
+                params: { id: "1" }
             });
         });
 


### PR DESCRIPTION
# Overview

This PR fixes the bug of Delete button not deleting entry in the Recommendation Table. 

# Issues Addressed & Details

Previously, clicking the Delete button would not delete an entry, but an error message would pop up. This is caused because the delete function is using the `requesterEmail` as an id to delete an entry. The `id` field should be used as a param to access an entry instead. 

Corresponding tests that are affected the change above are also adjusted.

# Test Coverages (Frontend)

- 100% Stryker Mutation Test `npx stryker run`
- 100% Test coverage `npm run test` / `npm run coverage`

fixes #73 
